### PR TITLE
add port forwards for better port visibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,6 +17,13 @@
 		}
 	},
 
+	"forwardPorts": [8080],
+	"portsAttributes": {
+		"8080": {
+			"visibility": "public"
+		}
+	},
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"java.home": "/docker-java-home"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Port 8080 was not exposed (forwarded) in the dev container.

## Short description of the changes
Added port forwarding config of 8080 so that it can be easier for users to access the webpage

## How to verify that this has the expected result
Users can now see the port 8080 exposed, and thus click the web button to easily access it.
<img width="818" alt="image" src="https://github.com/honeycombio/intro-to-o11y-java/assets/32691630/119f84f8-7268-45cb-80a6-35466ea9327b">
